### PR TITLE
Allow to use the body of the POST to send json for PDF

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,13 @@
 	        <version>5.58</version>
    		</dependency>
 
+		<!--  Required for Java >= 9 -->
+		<dependency>
+			<groupId>jakarta.xml.bind</groupId>
+			<artifactId>jakarta.xml.bind-api</artifactId>
+			<version>2.3.2</version>
+		</dependency>
+
 		<dependency>
 			<!-- ALWAYS required. -->
 			<groupId>com.openhtmltopdf</groupId>

--- a/src/main/java/dina/api/requests/CreatePDF.java
+++ b/src/main/java/dina/api/requests/CreatePDF.java
@@ -10,15 +10,16 @@ import javax.servlet.http.HttpServletResponse;
 
 import dina.LabelCreator.LabelCreator;
 import dina.LabelCreator.Options.Options;
+import org.apache.commons.lang3.StringUtils;
 import spark.Request;
 import spark.Response;
 
 public class CreatePDF {
 
 	public String template;
-	private Options op;
-	private Request req;
-	private Response res;
+	private final Options op;
+	private final Request req;
+	private final Response res;
 
 	private List<String> codesForCleanUp = new ArrayList<>();
 	
@@ -30,13 +31,17 @@ public class CreatePDF {
 
 	public HttpServletResponse result() throws IOException {
 		   
-			if(req.queryParams("template")!=null)
-				op.templateFile = op.templateDir+"/"+req.queryParams("template");
-		
-		   LabelCreator labels = new LabelCreator(op, req.queryParams("data"));
-		   labels.baseURL = op.baseURL;
+			if(req.queryParams("template")!=null) {
+				op.templateFile = op.templateDir + "/" + req.queryParams("template");
+			}
+
+			// Try to get it from query params and if no there use the request body
+		  LabelCreator labelCreator = StringUtils.isNotBlank(req.queryParams("data")) ?
+					new LabelCreator(op, req.queryParams("data")) : new LabelCreator(op, req.body());
+
+		  labelCreator.baseURL = op.baseURL;
 		   //labels.baseURL = "http://"+req.host()+req.pathInfo();
-     	   labels.createPDF();
+		  labelCreator.createPDF();
      	   
      	   if(op.debug)
      		   System.out.println("Reading PDF: "+Paths.get(op.outputFile));


### PR DESCRIPTION
Since there is a limit in the length of query parameters this PR allows to send the data as the body of the request. It is backward compatible so it is still possible to use the query parameters. 