### PR TITLE
Allow pdf to use files from disk

### DIFF
--- a/src/main/java/dina/BarCoder/BarCoder.java
+++ b/src/main/java/dina/BarCoder/BarCoder.java
@@ -229,7 +229,7 @@ public class BarCoder {
 				hints.put(EncodeHintType.ERROR_CORRECTION, ErrorCorrectionLevel.H);
 		}
 		
-		File imgFile = new File(outputImagePath + "/" + data[1] + "__" + UUID.randomUUID().toString() + ".png");
+		File imgFile = new File(outputImagePath + "/" + UUID.randomUUID() + ".png");
 		try {
 			if(!imgFile.createNewFile())
 				return null;

--- a/src/main/java/dina/LabelCreator/LabelCreator.java
+++ b/src/main/java/dina/LabelCreator/LabelCreator.java
@@ -87,10 +87,11 @@ public class LabelCreator {
             OutputStream os;
               try {
                os = Files.newOutputStream(outputPath.toFile().toPath());
-       
+								twigHelper twigHelper = new twigHelper(options, Format.PDF);
                try {
                      PdfRendererBuilder builder = new PdfRendererBuilder();
-                     template = parseTwigTemplate(Format.PDF);
+
+                     template = parseTwigTemplate(twigHelper) ;
                      
                      builder.withHtmlContent(template, "/");
                      
@@ -108,15 +109,18 @@ public class LabelCreator {
                             // swallow
                      }
                }
+							 //cleanup generated QR
+								twigHelper.cleanup();
               }
               catch (IOException e) {
                      e.printStackTrace();
                      // LOG exception.
               }
+
 		return outputPath;
 	}
 
-	public String parseTwigTemplate(Format format) throws MalformedURLException, IOException{
+	public String parseTwigTemplate(twigHelper twigHelper) throws MalformedURLException, IOException{
 		
 		String twig;
 	
@@ -124,12 +128,10 @@ public class LabelCreator {
 		
 		java.util.ResourceBundle.clearCache();
 
-		twigHelper twigConf = new twigHelper(options, format);
-		
-		JtwigTemplate template = JtwigTemplate.fileTemplate(new File(templateFile).getAbsolutePath(), twigConf.configuration);
+		JtwigTemplate template = JtwigTemplate.fileTemplate(new File(templateFile).getAbsolutePath(), twigHelper.configuration);
 		JtwigModel model = JtwigModel.newModel().with("dataArray", data);
 		
-		model.with("format", format.toString());
+		model.with("format", twigHelper.getFormat().toString());
 		model.with("baseURL", baseURL);
 		model.with("staticFiles", baseURL+"/static");
 

--- a/src/main/java/dina/LabelCreator/Options/Options.java
+++ b/src/main/java/dina/LabelCreator/Options/Options.java
@@ -141,6 +141,11 @@ public class Options
 		Long deleteAfter = new Long(300000); //5 minutes
 		final File folder = new File(tmpDir);
 		System.out.println(tmpDir);
+
+		if(folder.listFiles() == null) {
+			return;
+		}
+
 		for (final File fileEntry : folder.listFiles()) {
 	        if (fileEntry.isDirectory()) {
 	            // skip

--- a/src/main/java/dina/LabelCreator/Options/Options.java
+++ b/src/main/java/dina/LabelCreator/Options/Options.java
@@ -2,6 +2,8 @@ package dina.LabelCreator.Options;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
@@ -31,10 +33,17 @@ public class Options
 	public int codeWidth;
 	public int codeHeight;
 	public String templateDir			= "templates";
-	public boolean sessionIsSet         = false;;
+	public boolean sessionIsSet         = false;
+
+	private final Path tempFolder;
 	
 	public Options() {
 		setDefaultOptions();
+		try {
+			tempFolder = Files.createTempDirectory("labels");
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
 	}
 	
 	private void setDefaultOptions() {
@@ -134,7 +143,11 @@ public class Options
 		}
 		
 	}
-	
+
+	public Path getTempFolder() {
+		return tempFolder;
+	}
+
 	public void cleanUp() {
 	
 		Long now = System.currentTimeMillis();

--- a/src/main/java/dina/api/requests/CreateHTML.java
+++ b/src/main/java/dina/api/requests/CreateHTML.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import dina.LabelCreator.Helper.twigHelper;
 import dina.LabelCreator.LabelCreator;
 import dina.LabelCreator.Options.Options;
 import spark.Request;
@@ -33,7 +34,8 @@ public class CreateHTML {
 		   //labels.baseURL = "http://"+req.host()+req.pathInfo();
 		   //String re = labels.parseTemplate();
 
-           String re = labels.parseTwigTemplate(LabelCreator.Format.HTML);
+		   twigHelper twigHelper = new twigHelper(op, LabelCreator.Format.HTML);
+       String re = labels.parseTwigTemplate(twigHelper);
            
 		   return re;
 	}

--- a/src/main/java/dina/api/requests/CreateHTML.java
+++ b/src/main/java/dina/api/requests/CreateHTML.java
@@ -33,7 +33,7 @@ public class CreateHTML {
 		   //labels.baseURL = "http://"+req.host()+req.pathInfo();
 		   //String re = labels.parseTemplate();
 
-           String re = labels.parseTwigTemplate("HTML");
+           String re = labels.parseTwigTemplate(LabelCreator.Format.HTML);
            
 		   return re;
 	}

--- a/src/main/java/dina/api/requests/CreatePDF.java
+++ b/src/main/java/dina/api/requests/CreatePDF.java
@@ -48,6 +48,10 @@ public class CreatePDF {
      		   System.out.println("Reading PDF: " + pdfPath);
      	   
      	   byte[] bytes = Files.readAllBytes(pdfPath);
+
+					//since we have the content we can discard the file
+					pdfPath.toFile().delete();
+
            HttpServletResponse raw = res.raw();
 
             raw.getOutputStream().write(bytes);

--- a/src/main/java/dina/api/requests/CreatePDF.java
+++ b/src/main/java/dina/api/requests/CreatePDF.java
@@ -2,6 +2,7 @@ package dina.api.requests;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,12 +42,12 @@ public class CreatePDF {
 
 		  labelCreator.baseURL = op.baseURL;
 		   //labels.baseURL = "http://"+req.host()+req.pathInfo();
-		  labelCreator.createPDF();
+		  Path pdfPath = labelCreator.createPDF();
      	   
      	   if(op.debug)
-     		   System.out.println("Reading PDF: "+Paths.get(op.outputFile));
+     		   System.out.println("Reading PDF: " + pdfPath);
      	   
-     	   byte[] bytes = Files.readAllBytes(Paths.get(op.outputFile));         
+     	   byte[] bytes = Files.readAllBytes(pdfPath);
            HttpServletResponse raw = res.raw();
 
             raw.getOutputStream().write(bytes);


### PR DESCRIPTION
The goals of that PR are the following:

- load images (QR codes for example) from file instead of urls. By doing that we don`t need to expose the generated files through a URL and it simplifies the cleanup of generated resources.
- tmp folder for generated content for PDF is now managed by the JMV (and not by configuration anymore)
- the `createCode` function will now ignore the filename since it`s already assigning a UUID to it.
- the behavior for `html` should have not changed